### PR TITLE
Fixed RAM-830.

### DIFF
--- a/src/MasterService.cc
+++ b/src/MasterService.cc
@@ -404,10 +404,11 @@ MasterService::enumerate(const WireFormat::Enumerate::Request* reqHdr,
     EnumerationIterator iter(*rpc->requestPayload,
             downCast<uint32_t>(sizeof(*reqHdr)), reqHdr->iteratorBytes);
 
-    Buffer payload;
-    // A rough upper bound on how much space will be available in the response.
+    // Put at most maxPayloadBytes of enumerated objects in the reply. This 
+    // limit is used to leave enough room in the reply buffer for the response 
+    // header and also the serialized iteration state at the end of enumeration.
     uint32_t maxPayloadBytes = downCast<uint32_t>(
-            Transport::MAX_RPC_LEN - sizeof(*respHdr) - reqHdr->iteratorBytes);
+            Transport::MAX_RPC_LEN - sizeof(*respHdr) - (1 << 20));
     Enumeration enumeration(
             reqHdr->tableId, reqHdr->keysOnly,
             reqHdr->tabletFirstHash,


### PR DESCRIPTION
Enumeration was incorrectly estimating the amount of space it would need at the
end of enumeration to append the resulting state of enumeration to send back to
the client. It was assumed that no more space would be needed than was needed
by the client to store the current state of enumeration in the request buffer.
However, for various reasons (listed below), this was not a correct assumption,
and so the enumeration call handler would occasionally underestimate this
space, resulting in writing past the end of the buffer when appending the new
enumeration state.

The fix for this was to overestimate this space at 1MB. Since RPC buffers must
be at least 8MB in size, this leaves at least 7MBs to store enumerated objects,
which is still much more than enough to amortize any RPC overheads.

Reasons for underestimating: 1) Enumeration state can grow in size when tablets
are split, migrated, or recovered.  2) Enumeration state is serialized using
protocol buffers, which are implemented using variable length field encoding.
After updating the enumeration state, it could be larger than the serialized
version received in the request buffer.  3) In the very first round of
enumeration the client sends the server 0 bytes of state, and the server
creates it for the first time.