### PR TITLE
Uses GCC diagnostic push and pop to temporarily disable diagnostics.

### DIFF
--- a/apps/ClusterPerf.cc
+++ b/apps/ClusterPerf.cc
@@ -45,12 +45,12 @@
 #include <iostream>
 #include <unordered_set>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/program_options.hpp>
 #include <boost/version.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 namespace po = boost::program_options;
 
 #include "BasicTransport.h"
@@ -62,6 +62,7 @@ namespace po = boost::program_options;
 #include "Util.h"
 
 #if __GNUC__ && (__GNUC__ >= 7)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-truncation"
 #endif
 
@@ -7551,6 +7552,6 @@ catch (std::exception& e) {
 }
 
 #if __GNUC__ && (__GNUC__ >= 7)
-#pragma GCC diagnostic warning "-Wformat-truncation"
+#pragma GCC diagnostic pop
 #endif
 

--- a/apps/CoordinatorCrashRecovery.cc
+++ b/apps/CoordinatorCrashRecovery.cc
@@ -22,14 +22,13 @@
 #include <iostream>
 #include <unordered_map>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #include <boost/program_options.hpp>
 #include <boost/version.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
-#pragma GCC diagnostic warning "-Wnon-virtual-dtor"
+#pragma GCC diagnostic pop
 
 #include "RamCloud.h"
 #include "CoordinatorClient.h"

--- a/nanobenchmarks/Perf.cc
+++ b/nanobenchmarks/Perf.cc
@@ -45,18 +45,18 @@
 #include <thread>
 #include <vector>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/program_options.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #if __cplusplus >= 201402L
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "flat_hash_map.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 #endif
 
 #include "Common.h"

--- a/src/BackupStorage.h
+++ b/src/BackupStorage.h
@@ -16,11 +16,11 @@
 #ifndef RAMCLOUD_BACKUPSTORAGE_H
 #define RAMCLOUD_BACKUPSTORAGE_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/dynamic_bitset.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Buffer.h"
 #include "Exception.h"

--- a/src/BasicTransport.h
+++ b/src/BasicTransport.h
@@ -19,11 +19,11 @@
 #include <deque>
 
 #if __cplusplus >= 201402L
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "flat_hash_map.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 #endif
 #include "BoostIntrusive.h"
 #include "Buffer.h"

--- a/src/BoostIntrusive.h
+++ b/src/BoostIntrusive.h
@@ -21,12 +21,12 @@
 #ifndef RAMCLOUD_BOOSTINTRUSIVE_H
 #define RAMCLOUD_BOOSTINTRUSIVE_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/set.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 namespace RAMCloud {
 

--- a/src/CodeLocation.cc
+++ b/src/CodeLocation.cc
@@ -13,11 +13,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <pcrecpp.h>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 #include "CodeLocation.h"
 
 namespace RAMCloud {

--- a/src/Common.h
+++ b/src/Common.h
@@ -31,11 +31,11 @@
 #include <cinttypes>
 #include <typeinfo>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/foreach.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #define foreach BOOST_FOREACH
 #define reverse_foreach BOOST_REVERSE_FOREACH

--- a/src/CoordinatorClient.h
+++ b/src/CoordinatorClient.h
@@ -16,6 +16,7 @@
 #ifndef RAMCLOUD_COORDINATORCLIENT_H
 #define RAMCLOUD_COORDINATORCLIENT_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "MasterRecoveryInfo.pb.h"
@@ -23,8 +24,7 @@
 #include "RecoveryPartition.pb.h"
 #include "TableConfig.pb.h"
 #include "ServerConfig.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "ClientException.h"
 #include "CoordinatorRpcWrapper.h"

--- a/src/CoordinatorServerList.h
+++ b/src/CoordinatorServerList.h
@@ -21,13 +21,13 @@
 #include <list>
 #include <deque>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "MasterRecoveryInfo.pb.h"
 #include "ServerListEntry.pb.h"
 #include "ServerList.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "AbstractServerList.h"
 #include "CoordinatorUpdateManager.h"

--- a/src/CoordinatorService.h
+++ b/src/CoordinatorService.h
@@ -18,13 +18,13 @@
 
 #include <unordered_set>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "ServerList.pb.h"
 #include "Tablets.pb.h"
 #include "TableConfig.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Common.h"
 #include "AdminClient.h"

--- a/src/CoordinatorUpdateManager.cc
+++ b/src/CoordinatorUpdateManager.cc
@@ -13,11 +13,11 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "CoordinatorUpdateInfo.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "CoordinatorUpdateManager.h"
 #include "Logger.h"

--- a/src/CycleCounter.h
+++ b/src/CycleCounter.h
@@ -72,6 +72,7 @@ class CycleCounter {
      *      stopped or canceled). Otherwise, 0 is returned.
      */
     uint64_t stop() {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         if (startTime == ~0UL)
             return 0;
@@ -79,7 +80,7 @@ class CycleCounter {
         uint64_t stopTime = (__is_empty(T) ? 0 : Cycles::rdtsc());
         uint64_t elapsed = stopTime - startTime;
         if (total != NULL)
-#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
+#pragma GCC diagnostic pop
             *total += elapsed;
         startTime = ~0UL;
         return elapsed;

--- a/src/DpdkDriver.cc
+++ b/src/DpdkDriver.cc
@@ -26,6 +26,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <rte_config.h>
 #include <rte_common.h>
@@ -35,7 +36,7 @@
 #include <rte_memcpy.h>
 #include <rte_ring.h>
 #include <rte_version.h>
-#pragma GCC diagnostic warning "-Wconversion"
+#pragma GCC diagnostic pop
 
 #include "Common.h"
 #include "Cycles.h"

--- a/src/EnumerationIterator.h
+++ b/src/EnumerationIterator.h
@@ -16,11 +16,11 @@
 #ifndef RAMCLOUD_ENUMERATIONITERATOR_H
 #define RAMCLOUD_ENUMERATIONITERATOR_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "EnumerationIterator.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Common.h"
 #include "Buffer.h"

--- a/src/ExternalStorage.h
+++ b/src/ExternalStorage.h
@@ -16,11 +16,11 @@
 #ifndef RAMCLOUD_EXTERNALSTORAGE_H
 #define RAMCLOUD_EXTERNALSTORAGE_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <google/protobuf/message.h>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Buffer.h"
 #include "Exception.h"

--- a/src/HomaTransport.h
+++ b/src/HomaTransport.h
@@ -19,11 +19,11 @@
 #include <deque>
 
 #if __cplusplus >= 201402L
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "flat_hash_map.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 #endif
 #include "BoostIntrusive.h"
 #include "Buffer.h"

--- a/src/Infiniband.h
+++ b/src/Infiniband.h
@@ -17,11 +17,11 @@
 #include <netinet/in.h>
 #include <infiniband/verbs.h>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "flat_hash_map.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Common.h"
 #include "Driver.h"

--- a/src/LargeBlockOfMemory.h
+++ b/src/LargeBlockOfMemory.h
@@ -20,12 +20,12 @@
 #include <sys/mman.h>
 #include <climits>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/type_traits.hpp>
 #include <boost/utility/enable_if.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Common.h"
 

--- a/src/Logger.cc
+++ b/src/Logger.cc
@@ -21,11 +21,11 @@
 #include <sys/stat.h>
 #include <stdexcept>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/lexical_cast.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Cycles.h"
 #include "LogCabinLogger.h"
@@ -244,6 +244,7 @@ Logger::setLogLevel(string module, string level)
     }
     int moduleLevel;
 // The uninitialized variable is inside boost::lexical_cast.
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     try {
         moduleLevel = boost::lexical_cast<int>(level);
@@ -261,7 +262,7 @@ Logger::setLogLevel(string module, string level)
         }
     }
     setLogLevel(static_cast<LogModule>(moduleIndex), moduleLevel);
-#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
+#pragma GCC diagnostic pop
 }
 
 /**
@@ -322,6 +323,7 @@ void
 Logger::setLogLevels(string level)
 {
 // The uninitialized variable is inside boost::lexical_cast.
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
     // No lock needed: doesn't access Logger object.
     int moduleLevel;
@@ -341,7 +343,7 @@ Logger::setLogLevels(string level)
         }
     }
     setLogLevels(moduleLevel);
-#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
+#pragma GCC diagnostic pop
 }
 
 /**

--- a/src/MockTransport.h
+++ b/src/MockTransport.h
@@ -13,9 +13,10 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <gtest/gtest.h>
-#pragma GCC diagnostic warning "-Wconversion"
+#pragma GCC diagnostic pop
 #include <queue>
 
 #include "ServiceLocator.h"

--- a/src/ObjectFinder.h
+++ b/src/ObjectFinder.h
@@ -16,11 +16,11 @@
 #ifndef RAMCLOUD_OBJECTFINDER_H
 #define RAMCLOUD_OBJECTFINDER_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <boost/function.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include <map>
 

--- a/src/OptionParser.h
+++ b/src/OptionParser.h
@@ -16,13 +16,12 @@
 #ifndef RAMCLOUD_OPTIONPARSER_H
 #define RAMCLOUD_OPTIONPARSER_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
 #include <boost/program_options.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
-#pragma GCC diagnostic warning "-Wnon-virtual-dtor"
+#pragma GCC diagnostic pop
 
 #include "Transport.h"
 

--- a/src/PerfStats.cc
+++ b/src/PerfStats.cc
@@ -461,6 +461,7 @@ PerfStats::parseStats(Buffer* rawData, std::vector<PerfStats>* results)
  *      Optional scale factor; if specified, each metric will be
  *      multiplied by this value before printing.
  */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 string
 PerfStats::formatMetric(PerfStats::Diff* diff, const char* metric,
@@ -475,7 +476,7 @@ PerfStats::formatMetric(PerfStats::Diff* diff, const char* metric,
     }
     return result;
 }
-#pragma GCC diagnostic warning "-Wformat-nonliteral"
+#pragma GCC diagnostic pop
 
 /**
  * Generates a formatted string containing the rate per second of a given
@@ -496,6 +497,7 @@ PerfStats::formatMetric(PerfStats::Diff* diff, const char* metric,
  *      Optional scale factor; if specified, each rate will be multiplied
  *      by this value before printing.
  */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 string
 PerfStats::formatMetricRate(PerfStats::Diff* diff, const char* metric,
@@ -523,7 +525,7 @@ PerfStats::formatMetricRate(PerfStats::Diff* diff, const char* metric,
     }
     return result;
 }
-#pragma GCC diagnostic warning "-Wformat-nonliteral"
+#pragma GCC diagnostic pop
 
 /**
  * Generates a formatted string containing the ratio of two metrics for
@@ -546,6 +548,7 @@ PerfStats::formatMetricRate(PerfStats::Diff* diff, const char* metric,
  *      Optional scale factor; if specified, each ratio will be
  *      multiplied by this value before printing.
  */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 string
 PerfStats::formatMetricRatio(PerfStats::Diff* diff, const char* metric1,
@@ -566,6 +569,6 @@ PerfStats::formatMetricRatio(PerfStats::Diff* diff, const char* metric1,
     }
     return result;
 }
-#pragma GCC diagnostic warning "-Wformat-nonliteral"
+#pragma GCC diagnostic pop
 
 }  // namespace RAMCloud

--- a/src/RamCloud.h
+++ b/src/RamCloud.h
@@ -24,13 +24,13 @@
 #include "OptionParser.h"
 #include "ServerMetrics.h"
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "LogMetrics.pb.h"
 #include "ServerConfig.pb.h"
 #include "ServerStatistics.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 namespace RAMCloud {
 class ClientLeaseAgent;

--- a/src/ServerMetrics.cc
+++ b/src/ServerMetrics.cc
@@ -13,11 +13,11 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "MetricList.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Buffer.h"
 #include "ServerMetrics.h"

--- a/src/ServiceLocator.h
+++ b/src/ServiceLocator.h
@@ -17,12 +17,12 @@
 #define RAMCLOUD_SERVICELOCATOR_H
 
 #include <errno.h>
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include <pcrecpp.h>
 #include <boost/lexical_cast.hpp>
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include <map>
 #include <stdexcept>
@@ -203,9 +203,10 @@ class ServiceLocator {
  */
 template<typename T> T
 ServiceLocator::getOption(const string& key) const {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         return boost::lexical_cast<T>(getOption(key));
-#pragma GCC diagnostic warning "-Wmaybe-uninitialized"
+#pragma GCC diagnostic pop
 }
 
 /**

--- a/src/SpinLock.h
+++ b/src/SpinLock.h
@@ -20,11 +20,11 @@
 #include <atomic>
 #include <x86intrin.h>
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "SpinLockStatistics.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 namespace RAMCloud {
 

--- a/src/Tablet.h
+++ b/src/Tablet.h
@@ -16,11 +16,11 @@
 #ifndef RAMCLOUD_TABLET_H
 #define RAMCLOUD_TABLET_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Weffc++"
 #include "Tablets.pb.h"
-#pragma GCC diagnostic warning "-Wconversion"
-#pragma GCC diagnostic warning "-Weffc++"
+#pragma GCC diagnostic pop
 
 #include "Common.h"
 #include "Log.h"

--- a/src/TestUtil.h
+++ b/src/TestUtil.h
@@ -21,9 +21,10 @@
 #ifndef RAMCLOUD_TESTUTIL_H
 #define RAMCLOUD_TESTUTIL_H
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #include <gtest/gtest.h>
-#pragma GCC diagnostic warning "-Wconversion"
+#pragma GCC diagnostic pop
 #include <regex.h>
 #include <sstream>
 

--- a/src/TimeTrace.h
+++ b/src/TimeTrace.h
@@ -198,9 +198,10 @@ class TimeTrace {
         template<typename... Args>
         inline void record(uint64_t timestamp, const char* format, Args... args)
         {
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
             uint32_t eventArgs[] = {args...};
-#pragma GCC diagnostic warning "-Wnarrowing"
+#pragma GCC diagnostic pop
             if (expect_true(TimeTrace::activeReaders == 0)) {
                 Event* event = &events[nextIndex];
                 nextIndex = (nextIndex + 1) & BUFFER_MASK;


### PR DESCRIPTION
The use of:
pragma GCC diagnostic ignored "-Weffc++"
....
pragma GCC diagnostic warning "-Weffc++"

enables "-Weffc++" in the including file. This is undesirable. This commit
switches to using the push and pop to maintain the diagnostic state.