### PR TITLE
Adds deterministic id selection for BackupSelector

### DIFF
--- a/src/AbstractLogTest.cc
+++ b/src/AbstractLogTest.cc
@@ -57,7 +57,7 @@ class AbstractLogTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(ServerConfig::forTesting()),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           masterTableMetadata(),
           allocator(&serverConfig),
           segmentManager(&context, &serverConfig, &serverId,

--- a/src/BackupSelector.cc
+++ b/src/BackupSelector.cc
@@ -61,6 +61,7 @@ BackupSelector::BackupSelector(Context* context, const ServerId* serverId,
     , allowLocalBackup(allowLocalBackup)
     , replicationIdMap()
     , okToLogNextProblem(true)
+    , maxAttempts(100)
 {
 }
 
@@ -119,8 +120,8 @@ ServerId
 BackupSelector::selectSecondary(uint32_t numBackups,
                                 const ServerId backupIds[])
 {
-    int attempts;
-    for (attempts = 0; attempts < 100; attempts++) {
+    uint32_t attempts = 0;
+    for (attempts = 0; attempts < maxAttempts; attempts++) {
         applyTrackerChanges();
         ServerId id = tracker.getRandomServerIdWithService(
             WireFormat::BACKUP_SERVICE);

--- a/src/BackupSelector.h
+++ b/src/BackupSelector.h
@@ -123,6 +123,12 @@ class BackupSelector : public BaseBackupSelector {
      */
     bool okToLogNextProblem;
 
+    /**
+     * Indicates the maximum number of attempts to find a secondary 
+     * serverId.
+     */
+    const uint32_t maxAttempts;
+
   PRIVATE:
     bool conflict(const ServerId backupId,
                   const ServerId otherBackupId) const;

--- a/src/CleanableSegmentManagerTest.cc
+++ b/src/CleanableSegmentManagerTest.cc
@@ -96,7 +96,7 @@ class CleanableSegmentManagerTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           allocator(serverConfig()),
           masterTableMetadata(),
           segmentManager(&context, serverConfig(), &serverId,

--- a/src/LockTableTest.cc
+++ b/src/LockTableTest.cc
@@ -49,7 +49,7 @@ class LockTableTest : public ::testing::Test {
         , serverId(ServerId(57, 0))
         , serverList(&context)
         , serverConfig(ServerConfig::forTesting())
-        , replicaManager(&context, &serverId, 0, false, false)
+        , replicaManager(&context, &serverId, 0, false, false, false)
         , masterTableMetadata()
         , allocator(&serverConfig)
         , segmentManager(&context, &serverConfig, &serverId,

--- a/src/LogCleanerTest.cc
+++ b/src/LogCleanerTest.cc
@@ -108,7 +108,7 @@ class LogCleanerTest : public ::testing::Test {
           serverList(&context),
           masterTableMetadata(),
           serverConfig(),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           allocator(serverConfig()),
           segmentManager(&context, serverConfig(), &serverId,
                          allocator, replicaManager, &masterTableMetadata),

--- a/src/LogEntryRelocatorTest.cc
+++ b/src/LogEntryRelocatorTest.cc
@@ -42,7 +42,7 @@ class LogEntryRelocatorTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(ServerConfig::forTesting()),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           masterTableMetadata(),
           allocator(&serverConfig),
           segmentManager(&context, &serverConfig, &serverId,

--- a/src/LogIteratorTest.cc
+++ b/src/LogIteratorTest.cc
@@ -57,7 +57,7 @@ class LogIteratorTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(ServerConfig::forTesting()),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           masterTableMetadata(),
           allocator(&serverConfig),
           segmentManager(&context, &serverConfig, &serverId,

--- a/src/LogTest.cc
+++ b/src/LogTest.cc
@@ -59,7 +59,7 @@ class LogTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(ServerConfig::forTesting()),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           masterTableMetadata(),
           allocator(&serverConfig),
           segmentManager(&context, &serverConfig, &serverId,

--- a/src/Makefrag
+++ b/src/Makefrag
@@ -124,6 +124,7 @@ SHARED_SRCFILES := \
 		   src/PcapFile.cc \
 		   src/PerfCounter.cc \
 		   src/PerfStats.cc \
+		   src/PlusOneBackupSelector.cc \
 		   src/PortAlarm.cc \
 		   src/PreparedOp.cc \
 		   src/RamCloud.cc \

--- a/src/MakefragTest
+++ b/src/MakefragTest
@@ -122,6 +122,7 @@ TESTS_SRCFILES := \
 		  src/ParticipantListTest.cc \
 		  src/PerfCounterTest.cc \
 		  src/PerfStatsTest.cc \
+		  src/PlusOneBackupSelectorTest.cc \
 		  src/PortAlarm.cc \
 		  src/PortAlarmTest.cc \
 		  src/PreparedOpTest.cc \

--- a/src/MasterServiceTest.cc
+++ b/src/MasterServiceTest.cc
@@ -4252,7 +4252,7 @@ TEST_F(MasterServiceTest, detectSegmentRecoveryFailure_failure) {
 TEST_F(MasterServiceTest, recover_basics) {
     cluster.coordinator->recoveryManager.start();
     ServerId serverId(123, 0);
-    ReplicaManager mgr(&context, &serverId, 1, false, false);
+    ReplicaManager mgr(&context, &serverId, 1, false, false, false);
 
     // Create a segment with objectSafeVersion 23
     writeRecoverableSegment(&context, mgr, serverId, serverId.getId(), 87, 23U);
@@ -4346,7 +4346,7 @@ TEST_F(MasterServiceTest, recover_basics) {
 TEST_F(MasterServiceTest, recover_basic_indexlet) {
     cluster.coordinator->recoveryManager.start();
     ServerId serverId(123, 0);
-    ReplicaManager mgr(&context, &serverId, 1, false, false);
+    ReplicaManager mgr(&context, &serverId, 1, false, false, false);
 
     // Create a segment with objectSafeVersion 23
     writeRecoverableSegment(&context, mgr, serverId, serverId.getId(),
@@ -4446,7 +4446,7 @@ TEST_F(MasterServiceTest, recover_basic_indexlet) {
 TEST_F(MasterServiceTest, recover) {
     ServerId serverId(123, 0);
 
-    ReplicaManager mgr(&context, &serverId, 1, false, false);
+    ReplicaManager mgr(&context, &serverId, 1, false, false, false);
     writeRecoverableSegment(&context, mgr, serverId, serverId.getId(), 88);
 
     ServerConfig backup2Config = backup1Config;
@@ -4728,7 +4728,7 @@ TEST_F(MasterRecoverTest, recover) {
             {WireFormat::BACKUP_SERVICE, WireFormat::ADMIN_SERVICE},
             100, ServerStatus::UP});
     ServerId serverId(99, 0);
-    ReplicaManager mgr(&context2, &serverId, 1, false, false);
+    ReplicaManager mgr(&context2, &serverId, 1, false, false, false);
     MasterServiceTest::writeRecoverableSegment(&context, mgr, serverId, 99, 87);
     MasterServiceTest::writeRecoverableSegment(&context, mgr, serverId, 99, 88);
 

--- a/src/ObjectManager.cc
+++ b/src/ObjectManager.cc
@@ -86,6 +86,7 @@ ObjectManager::ObjectManager(Context* context, ServerId* serverId,
     , replicaManager(context, serverId,
                      config->master.numReplicas,
                      config->master.useMinCopysets,
+                     config->master.usePlusOneBackup,
                      config->master.allowLocalBackup)
     , segmentManager(context, config, serverId,
                      allocator, replicaManager, masterTableMetadata)

--- a/src/PlusOneBackupSelector.cc
+++ b/src/PlusOneBackupSelector.cc
@@ -1,0 +1,90 @@
+/* Copyright (c) 2011-2019 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <algorithm>
+
+#include "Cycles.h"
+#include "PlusOneBackupSelector.h"
+#include "ShortMacros.h"
+
+namespace RAMCloud {
+
+// --- PlusOneBackupSelector ---
+
+/**
+ * Constructor.
+ * \param context
+ *      Overall information about this RAMCloud server; used to register
+ *      #tracker with this server's ServerList.
+ * \param serverId
+ *      The ServerId of the backup. Used for selecting appropriate primary
+ *      and secondary replicas.
+ * \param numReplicas
+ *      The replication factor of each segment.
+ * \param allowLocalBackup
+ *      Specifies whether to allow replication to the local backup.
+ */
+PlusOneBackupSelector::PlusOneBackupSelector(Context* context,
+    const ServerId* serverId, uint32_t numReplicas, bool allowLocalBackup)
+    : BackupSelector(context, serverId, numReplicas, allowLocalBackup)
+{
+}
+
+
+/**
+ * Select a node that's masterServerId+1 with wraparound, or if that fails, 
+ * keep moving forward one with wraparound until you either find a node or 
+ * tried them all.
+ * \param numBackups
+ *      The number of entries in the \a backupIds array.
+ * \param backupIds
+ *      An array of numBackups backup ids, none of which may conflict with the
+ *      returned backup. All existing replica locations as well as the
+ *      server id of the master should be listed.
+ */
+ServerId
+PlusOneBackupSelector::selectSecondary(uint32_t numBackups,
+                                       const ServerId backupIds[])
+{
+    applyTrackerChanges();
+    uint32_t totalAttempts = std::min(tracker.size(), maxAttempts);
+    uint32_t attempts = 0;
+    uint32_t index = serverId->indexNumber();
+    
+    for (attempts = 0; attempts < totalAttempts; attempts++) {
+        applyTrackerChanges();
+        index++;
+        if (index > tracker.size()) {
+            index = 1;
+        }
+        ServerId id = tracker.getServerIdAtIndexWithService(
+            index, WireFormat::BACKUP_SERVICE);
+        if (id.isValid() &&
+            !conflictWithAny(id, numBackups, backupIds)) {
+            okToLogNextProblem = true;
+            return id;
+        }
+    }
+    if (okToLogNextProblem) {
+        RAMCLOUD_CLOG(WARNING, "PlusOneBackupSelector could not find a "
+            "suitable server in %d attempts; may need to wait for additional "
+            "servers to enlist",
+            attempts);
+        okToLogNextProblem = false;
+    }
+    return ServerId(/* Invalid */);
+}
+
+} // namespace RAMCloud

--- a/src/PlusOneBackupSelector.h
+++ b/src/PlusOneBackupSelector.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2011-2019 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef RAMCLOUD_PLUSONEBACKUPSELECTOR_H
+#define RAMCLOUD_PLUSONEBACKUPSELECTOR_H
+
+#include "Common.h"
+#include "BackupSelector.h"
+
+namespace RAMCloud {
+
+/**
+ * Selects backups to store replicas starting with (masterServerId+1)%n
+ */
+class PlusOneBackupSelector : public BackupSelector {
+  PUBLIC:
+    explicit PlusOneBackupSelector(Context* context,
+                                       const ServerId* serverId,
+                                       uint32_t numReplicas,
+                                       bool allowLocalBackup);
+    ServerId selectSecondary(
+      uint32_t numBackups, const ServerId backupIds[]) override;
+
+  PRIVATE:
+    DISALLOW_COPY_AND_ASSIGN(PlusOneBackupSelector);
+};
+
+} // namespace RAMCloud
+
+#endif

--- a/src/PlusOneBackupSelectorTest.cc
+++ b/src/PlusOneBackupSelectorTest.cc
@@ -1,0 +1,101 @@
+/* Copyright (c) 2009-2019 Stanford University
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR(S) DISCLAIM ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL AUTHORS BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define _GLIBCXX_USE_SCHED_YIELD
+#include <thread>
+#undef _GLIBCXX_USE_SCHED_YIELD
+
+#include "TestUtil.h"
+#include "Common.h"
+#include "MockCluster.h"
+#include "PlusOneBackupSelector.h"
+#include "ServiceMask.h"
+#include "ShortMacros.h"
+
+namespace RAMCloud {
+
+struct PlusOneBackupSelectorTest : public ::testing::Test {
+    TestLog::Enable logEnabler;
+    Context context;
+    MockCluster cluster;
+    PlusOneBackupSelector* selector;
+
+    PlusOneBackupSelectorTest()
+        : logEnabler()
+        , context()
+        , cluster(&context)
+        , selector()
+    {
+        ServerConfig config = ServerConfig::forTesting();
+        config.services = {WireFormat::MASTER_SERVICE,
+                           WireFormat::ADMIN_SERVICE};
+        config.master.numReplicas = 1u;
+        config.master.usePlusOneBackup = true;
+        Server* server = cluster.addServer(config);
+        selector = static_cast<PlusOneBackupSelector*>(
+            server->master->objectManager.replicaManager.backupSelector.get());
+    }
+
+    void addDifferentHosts(std::vector<ServerId>& ids) {
+        ServerConfig config = ServerConfig::forTesting();
+        config.services = {WireFormat::BACKUP_SERVICE,
+                           WireFormat::ADMIN_SERVICE};
+        for (uint32_t i = 1; i < 10; i++) {
+            config.backup.mockSpeed = i * 10;
+            config.localLocator = format("mock:host=backup%u", i);
+            ids.push_back(cluster.addServer(config)->serverId);
+        }
+    }
+    DISALLOW_COPY_AND_ASSIGN(PlusOneBackupSelectorTest);
+};
+
+TEST_F(PlusOneBackupSelectorTest, selectSecondary) {
+    std::vector<ServerId> ids;
+    addDifferentHosts(ids);
+
+    ServerId id = selector->selectSecondary(0, NULL);
+    EXPECT_EQ(ServerId(2, 0), id);
+
+    const ServerId conflicts[] = { ids[0] };
+
+    id = selector->selectSecondary(1, &conflicts[0]);
+    EXPECT_EQ(ServerId(3, 0), id);
+}
+
+TEST_F(PlusOneBackupSelectorTest, selectSecondary_logThrottling) {
+    // First problem: generate a log message.
+    TestLog::reset();
+    ServerId id = selector->selectSecondary(0, NULL);
+    EXPECT_EQ(ServerId(), id);
+    EXPECT_EQ("selectSecondary: PlusOneBackupSelector could not find a suitable "
+            "server in 1 attempts; may need to wait for additional "
+            "servers to enlist",
+            TestLog::get());
+    EXPECT_FALSE(selector->okToLogNextProblem);
+
+    // Recurring problem: no new message.
+    TestLog::reset();
+    id = selector->selectSecondary(0, NULL);
+    EXPECT_EQ("", TestLog::get());
+
+    // Successful completion: messages reenabled.
+    std::vector<ServerId> ids;
+    addDifferentHosts(ids);
+    id = selector->selectSecondary(0, NULL);
+    EXPECT_EQ(ServerId(2, 0), id);
+    EXPECT_TRUE(selector->okToLogNextProblem);
+}
+
+} // namespace RAMCloud

--- a/src/RecoverySegmentBuilderTest.cc
+++ b/src/RecoverySegmentBuilderTest.cc
@@ -44,7 +44,7 @@ struct RecoverySegmentBuilderTest : public ::testing::Test {
         , serverId(99, 0)
         , serverList(&context)
         , serverConfig(ServerConfig::forTesting())
-        , replicaManager(&context, &serverId, 0, false, false)
+        , replicaManager(&context, &serverId, 0, false, false, false)
         , masterTableMetadata()
         , allocator(&serverConfig)
         , segmentManager(&context, &serverConfig, &serverId,

--- a/src/ReplicaManager.h
+++ b/src/ReplicaManager.h
@@ -68,6 +68,7 @@ class ReplicaManager
                    const ServerId* masterId,
                    uint32_t numReplicas,
                    bool useMinCopysets,
+                   bool usePlusOneBackup,
                    bool allowLocalBackup);
     ~ReplicaManager();
 
@@ -194,6 +195,12 @@ class ReplicaManager
      * Specifies whether to use the MinCopysets replication scheme.
      */
     bool useMinCopysets;
+
+    /**
+     * Specifies whether to use the masterServerId plus one with wraparound 
+     * replication scheme.
+     */
+    bool usePlusOneBackup;
 
     /**
      * Specifies whether to allow replication to local backup.

--- a/src/ReplicaManagerTest.cc
+++ b/src/ReplicaManagerTest.cc
@@ -60,7 +60,7 @@ struct ReplicaManagerTest : public ::testing::Test {
         // anymore.
         serverId = CoordinatorClient::enlistServer(&context, 0, {},
             {WireFormat::MASTER_SERVICE}, "", 0);
-        mgr.construct(&context, &serverId, 2, false, false);
+        mgr.construct(&context, &serverId, 2, false, false, false);
         cluster.coordinatorContext.coordinatorServerList->sync();
     }
 

--- a/src/SegmentManagerTest.cc
+++ b/src/SegmentManagerTest.cc
@@ -46,7 +46,7 @@ class SegmentManagerTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(ServerConfig::forTesting()),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           masterTableMetadata(),
           allocator(&serverConfig),
           segmentManager(&context, &serverConfig, &serverId,

--- a/src/ServerConfig.h
+++ b/src/ServerConfig.h
@@ -238,6 +238,7 @@ struct ServerConfig {
             , numReplicas(0)
             , useHugepages(false)
             , useMinCopysets(false)
+            , usePlusOneBackup(false)
             , allowLocalBackup(false)
         {}
 
@@ -258,6 +259,7 @@ struct ServerConfig {
             , numReplicas()
             , useHugepages()
             , useMinCopysets()
+            , usePlusOneBackup()
             , allowLocalBackup()
         {}
 
@@ -278,6 +280,7 @@ struct ServerConfig {
             config.set_num_replicas(numReplicas);
             config.set_use_hugepages(useHugepages);
             config.set_use_mincopysets(useMinCopysets);
+            config.set_use_plusonebackup(usePlusOneBackup);
             config.set_use_local_backup(allowLocalBackup);
         }
 
@@ -299,6 +302,7 @@ struct ServerConfig {
             numReplicas = config.num_replicas();
             useHugepages = config.use_hugepages();
             useMinCopysets = config.use_mincopysets();
+            usePlusOneBackup = config.use_plusonebackup();
             allowLocalBackup = config.use_local_backup();
         }
 
@@ -344,6 +348,10 @@ struct ServerConfig {
         /// Specifies whether to use MinCopysets replication or random
         /// replication.
         bool useMinCopysets;
+
+        /// Specifies whether to use masterServerId plus one with wraparound 
+        /// or random replication for backupServerId.
+        bool usePlusOneBackup;
 
         /// If true, allow replication to local backup.
         bool allowLocalBackup;

--- a/src/ServerConfig.proto
+++ b/src/ServerConfig.proto
@@ -94,6 +94,10 @@ message ServerConfig {
 
         /// If true, allow replication to local backup.
         required bool use_local_backup = 12;
+
+        /// Specifies whether to use masterServerId plus one with wraparound 
+        /// or random replication for backupServerId.
+        required bool use_plusonebackup = 13;
     }
 
     /// The server's MasterService configuration, if it is running one.

--- a/src/ServerMain.cc
+++ b/src/ServerMain.cc
@@ -237,6 +237,11 @@ main(int argc, char *argv[])
              ProgramOptions::value<bool>(&config.master.useMinCopysets)->
                 default_value(false),
              "Whether to use MinCopysets or random replication")
+            ("usePlusOneBackup",
+             ProgramOptions::value<bool>(&config.master.usePlusOneBackup)->
+                default_value(false),
+             "Whether to use (masterServerId+1)modulo n or random "
+             "replication for backupServerId")
             ("writeCostThreshold,w",
              ProgramOptions::value<uint32_t>(
                 &config.master.cleanerWriteCostThreshold)->default_value(8),

--- a/src/ServerTracker.h
+++ b/src/ServerTracker.h
@@ -397,6 +397,34 @@ class ServerTracker : public ServerTrackerInterface {
     }
 
     /**
+     * Deterministically obtain the ServerId at serverList[index], but only
+     * if index is valid, the serverId is valid, the server is up, and it
+     * has the specified service. We return invalid id otherwise.
+     * 
+     * \param index
+     *      The index of serverList[] we want returned.
+     * \param service
+     *      Restricts returned ServerId to a server that was known by this tracker
+     *      to be running an instance of a specific service type.
+     * \return
+     *      The ServerId of a server that was known by this tracker to be
+     *      running an instance of the requested service type, provided the
+     *      criteria passes.
+     */
+    ServerId
+    getServerIdAtIndexWithService(uint32_t index, WireFormat::ServiceType service) {
+        if (serverList.size() > 0 &&
+            index < serverList.size() &&
+            index != lastRemovedIndex &&
+            serverList[index].server.serverId.isValid() &&
+            serverList[index].server.status == ServerStatus::UP &&
+            serverList[index].server.services.has(service)) {
+            return serverList[index].server.serverId;
+        }
+        return ServerId(/* invalid id */);
+    }
+
+    /**
      * Obtain a random ServerId stored in this tracker which is running a
      * particular service.
      * The caller should check ServerId::isValid() since this method can

--- a/src/ServerTrackerTest.cc
+++ b/src/ServerTrackerTest.cc
@@ -380,6 +380,35 @@ TEST_F(ServerTrackerTest, getChange_removedButServerNeverAdded) {
     EXPECT_EQ(0u, tr.changes.size());
 }
 
+TEST_F(ServerTrackerTest, getServerIdAtIndexWithService) {
+    Logger::get().setLogLevels(SILENT_LOG_LEVEL);
+
+    ServerDetails server;
+    ServerChangeEvent event;
+
+    EXPECT_FALSE(tr.getServerIdAtIndexWithService(
+        1, WireFormat::BACKUP_SERVICE).isValid());
+
+    upEvent(ServerId(1, 0));
+    EXPECT_FALSE(tr.getServerIdAtIndexWithService(
+        1, WireFormat::BACKUP_SERVICE).isValid());
+    EXPECT_TRUE(tr.getChange(server, event));
+
+    EXPECT_EQ(ServerId(1, 0),
+                  tr.getServerIdAtIndexWithService(1, WireFormat::BACKUP_SERVICE));
+    // No host available with this service bit set.
+    EXPECT_EQ(ServerId(),
+                  tr.getServerIdAtIndexWithService(1, WireFormat::MASTER_SERVICE));
+
+    // Ensure looping over empty list terminates.
+    removedEvent(ServerId(1, 0));
+    while (tr.getChange(server, event)) {
+        // Do nothing; just process all events.
+    }
+    EXPECT_FALSE(tr.getServerIdAtIndexWithService(
+        1, WireFormat::BACKUP_SERVICE).isValid());
+}
+
 TEST_F(ServerTrackerTest, getRandomServerIdWithService) {
     Logger::get().setLogLevels(SILENT_LOG_LEVEL);
 

--- a/src/SideLogTest.cc
+++ b/src/SideLogTest.cc
@@ -57,7 +57,7 @@ class SideLogTest : public ::testing::Test {
           serverId(ServerId(57, 0)),
           serverList(&context),
           serverConfig(ServerConfig::forTesting()),
-          replicaManager(&context, &serverId, 0, false, false),
+          replicaManager(&context, &serverId, 0, false, false, false),
           masterTableMetadata(),
           allocator(&serverConfig),
           segmentManager(&context, &serverConfig, &serverId,


### PR DESCRIPTION
- Adds the PlusOneBackupSelector, which starts with masterServerId + 1 as a
    backupServer candidate, and keeps incrementing one forward with wraparound
    until either finding a valid backup server, or running out of attempts and
    giving up.
- PlusOneBackupSelector class behaves deterministically for selecting a
    backupServer like MinCopysetsBackupSelector, except it ignores replicationId.
- We also add the corresponding --usePlusOneBackup commandline argument to
    ServerMain, similar to --useMinCopysets.
- This allows for simple integration testing where we want to predict what the
    backup server id is based on the master id without needing to "second guess"
    the random seed.